### PR TITLE
Bump Specmatic to 2.39.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <kotlin.version>2.3.10</kotlin.version>
         <maven.compiler>17</maven.compiler>
-        <specmatic.version>2.39.1</specmatic.version>
+        <specmatic.version>2.39.2</specmatic.version>
         <spring.boot.version>3.5.10</spring.boot.version>
     </properties>
 


### PR DESCRIPTION
## Summary
- bump Specmatic OSS version references to 2.39.2
- keep Specmatic Enterprise at 1.1.2

## Notes
- this PR updates dependency/version declarations only